### PR TITLE
Feature/options from cli

### DIFF
--- a/bin/larry
+++ b/bin/larry
@@ -12,6 +12,8 @@ var program = require("commander"),
 program
     .version(packagejson.version)
     .option("-c, --config [path]", "Path to JSON configuration file. Default '../config/larry.json' in the current directory.")
+    .option("--options.input [path]", "Relative path from where files are referenced")
+    .option("--options.output [path]", "Path to where packages are created in")
     .parse(process.argv);
 
 /**

--- a/bin/larry
+++ b/bin/larry
@@ -12,8 +12,8 @@ var program = require("commander"),
 program
     .version(packagejson.version)
     .option("-c, --config [path]", "Path to JSON configuration file. Default '../config/larry.json' in the current directory.")
-    .option("--options.input [path]", "Relative path from where files are referenced")
-    .option("--options.output [path]", "Path to where packages are created in")
+    .option("--options-input [path]", "Relative path from where files are referenced")
+    .option("--options-output [path]", "Path to where packages are created in")
     .parse(process.argv);
 
 /**

--- a/src/core.js
+++ b/src/core.js
@@ -38,12 +38,12 @@ module.exports = {
 
         //Check if options.input and options.output parameters are passed as arguments. This will override config options in the larry JSON config file
 
-        if(program["options.input"]){
-            config.options.input = (program["options.input"]).toString();
+        if(program["options-input"]){
+            config.options.input = (program["options-input"]).toString();
         }
 
-        if(program["options.output"]){
-            config.options.output = (program["options.output"]).toString();
+        if(program["options-output"]){
+            config.options.output = (program["options-output"]).toString();
         }
 
 

--- a/src/core.js
+++ b/src/core.js
@@ -28,12 +28,24 @@ module.exports = {
         // Load config file data
         try {
             config = fs.readFileSync(path.resolve(program.config)).toString();
+            config = JSON.parse(config);
         }
             // If config file is not found, or cannot be parsed, throw error and stop execution
         catch (err) {
             console.log(program);
             throw new Error("Could not parse JSON config file: " + err);
         }
+
+        //Check if options.input and options.output parameters are passed as arguments. This will override config options in the larry JSON config file
+
+        if(program['options.input']){
+            config.options.input = (program['options.input']).toString();
+        }
+
+        if(program['options.output']){
+            config.options.output = (program['options.output']).toString();
+        }
+
 
         //Initializing objects
 

--- a/src/core.js
+++ b/src/core.js
@@ -38,12 +38,12 @@ module.exports = {
 
         //Check if options.input and options.output parameters are passed as arguments. This will override config options in the larry JSON config file
 
-        if(program['options.input']){
-            config.options.input = (program['options.input']).toString();
+        if(program["options.input"]){
+            config.options.input = (program["options.input"]).toString();
         }
 
-        if(program['options.output']){
-            config.options.output = (program['options.output']).toString();
+        if(program["options.output"]){
+            config.options.output = (program["options.output"]).toString();
         }
 
 

--- a/src/lib.js
+++ b/src/lib.js
@@ -33,7 +33,7 @@ var larry = function (config, schema) {
 
     //Initializing config and schema
 
-    self.config = JSON.parse(config);
+    self.config = config;
     self.schema = JSON.parse(schema);
 
     schemaValidatorLog = schemaValidatorEnv.validate(self.config, self.schema);


### PR DESCRIPTION
larry options [input and output] can now be passed from cli arguments similar to how config file was passed. This was done by parsing the inputs using commander and overriding config.options.[input/output] values if they are passed.
