### PR TITLE
Fixes issue #3 where the `package.json` was referring to retired bitbuck...

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 
     "repository": {
         "type": "git",
-        "url": "https://bitbucket.org/fusioncharts/larry.git"
+        "url": "https://github.com/fusioncharts/larry.git"
     },
 
     "devDependencies": {


### PR DESCRIPTION
The `package.json` was pointing to retired Bitbucket repository URL. The same has been updated with the Github URL.

NPM will not reflect the change until v0.0.5 is created and published. Once the changes made by @ritesh-pandey  is peer-reviewed by @rohitb4 or @kaustavdm or @bhargav3, we can release v0.0.5
